### PR TITLE
[gemm][rocm][quantization] Fix incorrect dequantization on MI300

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Petit provides python APIs for matrix multiplications that are intended to be in
 
 ## Techniques and Evaluations
 
-Petit adopts the core ideas from [Marlin](https://github.com/IST-DASLab/marlin.git) and tailors the ideas optimizations for the throughput-oriented CDNA2 and CDNA3 architectures. Detailed information about these optimizations is available in a separate article.
+Similar to [Marlin](https://github.com/IST-DASLab/marlin.git), Petit performs offline weight shuffling to enable efficient GPU dequantization. To achieve optimal performance, Petit utilizes ranged buffer loads and vector instructions specifically designed for CDNA2 and CDNA3 architectures. These optimizations are based on the assumptions that scales remain positive and quantized weights contain no negative zeros. For detailed information about these optimizations, please refer to the documentation available [here](https://www.causalflow.ai/blogs/2025-08-optimizing-fp4-mixed-precision-inference-on-amd-gpus).
 
 Petit is optimized for the real-world use cases where the LLM engines perform inferences with small batches. For example, Petit is 1.2x-2.2x faster compared to [hipBLASLt](https://rocm.docs.amd.com/projects/hipBLASLt/en/latest) when performing BF16 matrix multiplications when batch size less than 16. For larger batches where the performance is bound by the available computational powers, Petit performs within 70% of the hand-optimized hipBLASLt library.
 

--- a/lib/gemm/rocm/quantization/fp4/gemm_fp4_fp16_grid.cuh
+++ b/lib/gemm/rocm/quantization/fp4/gemm_fp4_fp16_grid.cuh
@@ -464,8 +464,8 @@ __launch_bounds__(Config::kThreads) __global__
                            MultiStagePipeline<Config>>;
     using ArchMma =
         MmaSelector<typename Config::ElementA, Config::kHighPrecision>;
-    using DS = ArchMma::DS;
-    float global_scale = *global_scale_ptr * DS::GlobalScaleFactor();
+    float global_scale =
+        *global_scale_ptr * ArchMma::UDQ::DS::GlobalScaleFactor();
 
     [[assume(tid < Config::kThreads)]];
 
@@ -528,8 +528,6 @@ template <SolutionId id> struct ConfigSelector {
     using WP = WarpPartition<kPartitionM, kPartitionN, kPartitionK>;
     using Config = GEMMFp4Fp16Config<TS, WP, kPipelineStages, kHighPrecision>;
     using ArchMma = MmaSelector<typename Config::ElementA, kHighPrecision>;
-    using DQ = ArchMma::DQ;
-    using DS = ArchMma::DS;
 
     static constexpr unsigned kNumWarps = WP::kNumWarps;
 

--- a/lib/gemm/rocm/quantization/fp4/quantization_utils.cu
+++ b/lib/gemm/rocm/quantization/fp4/quantization_utils.cu
@@ -134,8 +134,13 @@ __device__ static unsigned PetitFormat(unsigned v) {
             off_d = off_s + 4;
         }
         unsigned u = (v >> (i * 4)) & 0xf;
-        unsigned sgn = u >> 3;
         unsigned val = u & 0x7;
+
+        // Change negative zero to positive zero as in MI300x natively
+        // supports e5m2fnuz where 0x80 will be incorrectly dequantized to NaN
+        // in Petit.
+        unsigned sgn = val == 0 ? 0 : u >> 3;
+
         if (i >= 4) {
             val = __builtin_bitreverse32(val) >> 29;
         }

--- a/lib/gemm/rocm/quantization/fp4/warp_schedule_fp16.cuh
+++ b/lib/gemm/rocm/quantization/fp4/warp_schedule_fp16.cuh
@@ -10,8 +10,6 @@ namespace causalflow::petit::rocm::quantization::fp4 {
 template <class ElementA, bool kHighPrecision> struct MmaSelector;
 
 template <bool kHighPrecision> struct MmaSelector<__half, kHighPrecision> {
-    using DQ = Dequantizer<half2, kDataTypeFp4e2m1>;
-    using DS = DequantizerForFp8Scale<half2, !kHighPrecision>;
     using UDQ = UnifiedDequantizerForFp4Fp16<kHighPrecision>;
 
     __device__ static inline float4 Mma(uint2 fa, uint2 fb, float4 c) {
@@ -21,8 +19,6 @@ template <bool kHighPrecision> struct MmaSelector<__half, kHighPrecision> {
 
 template <bool kHighPrecision>
 struct MmaSelector<__hip_bfloat16, kHighPrecision> {
-    using DQ = Dequantizer<__hip_bfloat162, kDataTypeFp4e2m1>;
-    using DS = DequantizerForFp8Scale<__hip_bfloat162, !kHighPrecision>;
     using UDQ = UnifiedDequantizerForFp4Bf16<kHighPrecision>;
 
     __device__ static inline float4 Mma(uint2 fa, uint2 fb, float4 c) {

--- a/lib/gemm/rocm/quantization/types.h
+++ b/lib/gemm/rocm/quantization/types.h
@@ -4,10 +4,10 @@ namespace causalflow::petit::rocm::quantization {
 enum DataType {
     kDataTypeInt4,
     kDataTypeFp8e4m3,
-    kDataTypeFp8e5m2Fnuz,
     kDataTypeFp4e2m1,
     kDataTypeFp16,
     kDataTypeBf16,
+    kDataTypeFp8e5m2Fnuz,
 };
 
 } // namespace causalflow::petit::rocm::quantization

--- a/lib/gemm/rocm/quantization/types.h
+++ b/lib/gemm/rocm/quantization/types.h
@@ -4,6 +4,7 @@ namespace causalflow::petit::rocm::quantization {
 enum DataType {
     kDataTypeInt4,
     kDataTypeFp8e4m3,
+    kDataTypeFp8e5m2Fnuz,
     kDataTypeFp4e2m1,
     kDataTypeFp16,
     kDataTypeBf16,

--- a/lib/tests/quantization.h
+++ b/lib/tests/quantization.h
@@ -61,6 +61,7 @@ class GemmMPTestData {
         case DataType::kDataTypeBf16:
             return 2;
         case DataType::kDataTypeFp8e4m3:
+        case DataType::kDataTypeFp8e5m2Fnuz:
             return 1;
         default:
             throw std::runtime_error("Invalid quant data type");

--- a/petit_kernel/__init__.py
+++ b/petit_kernel/__init__.py
@@ -7,10 +7,11 @@ from .ops import PetitSolutionHints
 
 class DataType(enum.Enum):
     int4 = 0
-    float8_e4m3fn = 1
-    float4_e2m1 = 2
-    float16 = 3
-    bfloat16 = 4
+    float8_e4m3 = 1
+    float8_e5m2fn = 2
+    float4_e2m1 = 3
+    float16 = 4
+    bfloat16 = 5
 
 
 def repack_nvfp4(qw: torch.Tensor, size_n: int, size_k: int) -> torch.Tensor:
@@ -45,7 +46,7 @@ def get_fp4_solutions(
 __all__ = [
     "repack_nvfp4",
     "process_nvfp4_scales",
-    "mul_fp4_a16",
+    "mul_nvfp4_a16",
     "get_fp4_solutions",
     "DataType",
     "PetitSolutionHints",

--- a/petit_kernel/__init__.py
+++ b/petit_kernel/__init__.py
@@ -7,12 +7,11 @@ from .ops import PetitSolutionHints
 
 class DataType(enum.Enum):
     int4 = 0
-    float8_e4m3 = 1
-    float8_e5m2fn = 2
-    float4_e2m1 = 3
-    float16 = 4
-    bfloat16 = 5
-
+    float8_e4m3fn = 1
+    float4_e2m1 = 2
+    float16 = 3
+    bfloat16 = 4
+    float8_e5m2fn = 5
 
 def repack_nvfp4(qw: torch.Tensor, size_n: int, size_k: int) -> torch.Tensor:
     return ops.repack_nvfp4(qw, size_n, size_k)


### PR DESCRIPTION
## Motivation

The original implementation overlooked the following facts about the BF8 FNUZ format used on MI300:
* 0x80 should be treated as NaN rather than -0.0
* The exponent bias should be 16 instead of 15, causing incorrect dequantization results
In addition, there are also errors in the usage of intrinsics.

This PR fixes these issues, ensures correct dequantization on MI300.

## Modifications

This PR has performed the following fixes:
* Correctly handle the special exponent bias in the BF8 FNUZ format.
* Convert -0.0 to 0.0 during weight repacking to avoid being misinterpreted as NaN on MI300.
* Fix the FP4-to-BF16 dequantization method that uses BF8 intermediate variables.

These changes ensure correct dequantization on MI300.

## Outcome

This branch has been experimentally integrated into vLLM v0.10.1.1, and its output text is consistent with version v0.0.2.

## Checklist

- [x] Format the code according to project style guides (clang-format).
- [x] Ensure existing unit test to be unaffected.