### PR TITLE
[moe] Add activation and bias hooks

### DIFF
--- a/lib/moe/rocm/fused_moe.cuh
+++ b/lib/moe/rocm/fused_moe.cuh
@@ -19,11 +19,11 @@ __device__ static inline float4 Fma4(float4 a, float s, float4 c) {
 struct SiluDotOp {
     __device__ static inline float4 Apply(float4 gate, float4 up) {
         static constexpr float kMinusLog2e = -1.4426950408889634f;
-        static constexpr v2f kMinusLog2e2{kMinusLog2e, kMinusLog2e};
-        static constexpr v2f kOne2{1.0f, 1.0f};
-        auto *g2 = reinterpret_cast<const v2f *>(&gate);
+        static constexpr float2 kMinusLog2e2{kMinusLog2e, kMinusLog2e};
+        static constexpr float2 kOne2{1.0f, 1.0f};
+        auto *g2 = reinterpret_cast<const float2 *>(&gate);
         auto *u2 = reinterpret_cast<const float2 *>(&up);
-        v2f i2[2];
+        float2 i2[2];
 
         i2[0] = g2[0] * kMinusLog2e2;
         i2[1] = g2[1] * kMinusLog2e2;
@@ -39,34 +39,29 @@ struct SiluDotOp {
         i2[1][1] = __builtin_amdgcn_rcpf(i2[1][1]);
 
         float4 r;
-        auto *i2f = reinterpret_cast<const float2 *>(i2);
         reinterpret_cast<float2 &>(r) = amdgcn_pk_mul_f32(
-            amdgcn_pk_mul_f32(reinterpret_cast<const float2 &>(gate), i2f[0]),
+            amdgcn_pk_mul_f32(reinterpret_cast<const float2 &>(gate), i2[0]),
             u2[0]);
         reinterpret_cast<float2 *>(&r)[1] = amdgcn_pk_mul_f32(
-            amdgcn_pk_mul_f32(reinterpret_cast<const float2 *>(&gate)[1], i2f[1]),
+            amdgcn_pk_mul_f32(reinterpret_cast<const float2 *>(&gate)[1], i2[1]),
             u2[1]);
         return r;
     }
 };
 
-struct OpenAISwiGLUOp {
-    __device__ static inline float4 Apply(float4 gate, float4 up) {
-        static constexpr float kMinusAlphaLog2e = -2.455307455790015f;
-        static constexpr float kLimit = 7.0f;
-        float4 r;
-        const float *g = reinterpret_cast<const float *>(&gate);
-        const float *u = reinterpret_cast<const float *>(&up);
-        float *o = reinterpret_cast<float *>(&r);
-        for (int i = 0; i < 4; ++i) {
-            const float gc = fminf(g[i], kLimit);
-            const float uc = fminf(fmaxf(u[i], -kLimit), kLimit);
-            const float sig =
-                __builtin_amdgcn_rcpf(1.0f + amdgcn_exp2f(kMinusAlphaLog2e * gc));
-            o[i] = gc * sig * (uc + 1.0f);
-        }
-        return r;
-    }
+struct NoBiasOp {
+    template <class Kernel>
+    __device__ void Initialize(Kernel &kernel) {}
+
+    template <unsigned kAccumFragments>
+    __device__ void AddBiasStage1(float4 t_gate[kAccumFragments],
+                                  float4 t_up[kAccumFragments],
+                                  unsigned wid, unsigned wtid) {}
+
+    template <unsigned kAccumFragments>
+    __device__ void AddBiasStage2(float4 t_gate[kAccumFragments],
+                                  unsigned tile_d,
+                                  unsigned wid, unsigned wtid) {}
 };
 
 template <unsigned kInstMFMA, unsigned kInstVmemRead = 0,

--- a/lib/moe/rocm/fused_moe.cuh
+++ b/lib/moe/rocm/fused_moe.cuh
@@ -16,37 +16,58 @@ __device__ static inline float4 Fma4(float4 a, float s, float4 c) {
     return r;
 }
 
-__device__ static inline float4 SiluDot(float4 gate, float4 up) {
-    static constexpr float kMinusLog2e = -1.4426950408889634f;
-    static constexpr v2f kMinusLog2e2{kMinusLog2e, kMinusLog2e};
-    static constexpr v2f kOne2{1.0f, 1.0f};
-    auto *g2 = reinterpret_cast<const v2f *>(&gate);
-    auto *u2 = reinterpret_cast<const float2 *>(&up);
-    v2f i2[2];
+struct SiluDotOp {
+    __device__ static inline float4 Apply(float4 gate, float4 up) {
+        static constexpr float kMinusLog2e = -1.4426950408889634f;
+        static constexpr v2f kMinusLog2e2{kMinusLog2e, kMinusLog2e};
+        static constexpr v2f kOne2{1.0f, 1.0f};
+        auto *g2 = reinterpret_cast<const v2f *>(&gate);
+        auto *u2 = reinterpret_cast<const float2 *>(&up);
+        v2f i2[2];
 
-    i2[0] = g2[0] * kMinusLog2e2;
-    i2[1] = g2[1] * kMinusLog2e2;
-    i2[0][0] = amdgcn_exp2f(i2[0][0]);
-    i2[0][1] = amdgcn_exp2f(i2[0][1]);
-    i2[1][0] = amdgcn_exp2f(i2[1][0]);
-    i2[1][1] = amdgcn_exp2f(i2[1][1]);
-    i2[0] += kOne2;
-    i2[1] += kOne2;
-    i2[0][0] = __builtin_amdgcn_rcpf(i2[0][0]);
-    i2[0][1] = __builtin_amdgcn_rcpf(i2[0][1]);
-    i2[1][0] = __builtin_amdgcn_rcpf(i2[1][0]);
-    i2[1][1] = __builtin_amdgcn_rcpf(i2[1][1]);
+        i2[0] = g2[0] * kMinusLog2e2;
+        i2[1] = g2[1] * kMinusLog2e2;
+        i2[0][0] = amdgcn_exp2f(i2[0][0]);
+        i2[0][1] = amdgcn_exp2f(i2[0][1]);
+        i2[1][0] = amdgcn_exp2f(i2[1][0]);
+        i2[1][1] = amdgcn_exp2f(i2[1][1]);
+        i2[0] += kOne2;
+        i2[1] += kOne2;
+        i2[0][0] = __builtin_amdgcn_rcpf(i2[0][0]);
+        i2[0][1] = __builtin_amdgcn_rcpf(i2[0][1]);
+        i2[1][0] = __builtin_amdgcn_rcpf(i2[1][0]);
+        i2[1][1] = __builtin_amdgcn_rcpf(i2[1][1]);
 
-    float4 r;
-    auto *i2f = reinterpret_cast<const float2 *>(i2);
-    reinterpret_cast<float2 &>(r) = amdgcn_pk_mul_f32(
-        amdgcn_pk_mul_f32(reinterpret_cast<const float2 &>(gate), i2f[0]),
-        u2[0]);
-    reinterpret_cast<float2 *>(&r)[1] = amdgcn_pk_mul_f32(
-        amdgcn_pk_mul_f32(reinterpret_cast<const float2 *>(&gate)[1], i2f[1]),
-        u2[1]);
-    return r;
-}
+        float4 r;
+        auto *i2f = reinterpret_cast<const float2 *>(i2);
+        reinterpret_cast<float2 &>(r) = amdgcn_pk_mul_f32(
+            amdgcn_pk_mul_f32(reinterpret_cast<const float2 &>(gate), i2f[0]),
+            u2[0]);
+        reinterpret_cast<float2 *>(&r)[1] = amdgcn_pk_mul_f32(
+            amdgcn_pk_mul_f32(reinterpret_cast<const float2 *>(&gate)[1], i2f[1]),
+            u2[1]);
+        return r;
+    }
+};
+
+struct OpenAISwiGLUOp {
+    __device__ static inline float4 Apply(float4 gate, float4 up) {
+        static constexpr float kMinusAlphaLog2e = -2.455307455790015f;
+        static constexpr float kLimit = 7.0f;
+        float4 r;
+        const float *g = reinterpret_cast<const float *>(&gate);
+        const float *u = reinterpret_cast<const float *>(&up);
+        float *o = reinterpret_cast<float *>(&r);
+        for (int i = 0; i < 4; ++i) {
+            const float gc = fminf(g[i], kLimit);
+            const float uc = fminf(fmaxf(u[i], -kLimit), kLimit);
+            const float sig =
+                __builtin_amdgcn_rcpf(1.0f + amdgcn_exp2f(kMinusAlphaLog2e * gc));
+            o[i] = gc * sig * (uc + 1.0f);
+        }
+        return r;
+    }
+};
 
 template <unsigned kInstMFMA, unsigned kInstVmemRead = 0,
           unsigned kInstDsRead = 0, unsigned kInstDsWrite = 0,

--- a/lib/moe/rocm/fused_moe_blockscale_fp8_fp4_grid.cuh
+++ b/lib/moe/rocm/fused_moe_blockscale_fp8_fp4_grid.cuh
@@ -19,8 +19,6 @@
 
 namespace causalflow::petit::rocm::moe {
 
-template <class Config, unsigned kTokenBatch>
-struct FusedMoEBlockScaleFP8Fp4Stage1Trait;
 template <class Config> struct FusedMoEBlockScaleFP8Fp4Stage2Trait;
 
 __device__ static inline float4 Fma4(float4 a, float4 s, float4 c) {
@@ -99,13 +97,14 @@ MatmulBlockScaleFp4(float4 t[2 * kLoadGlobal], const uint4 w[kLoadGlobal],
     }
 }
 
-template <class Config, unsigned kTokenBatch>
+template <class Config, class ActivationOp_, unsigned kTokenBatch>
 struct FusedMoEBlockScaleFP8Fp4Stage1Trait {
     static constexpr unsigned kNumWarps = Config::kNumWarps;
     static constexpr unsigned kActivationFragments = Config::kGroupDim / 32;
     static constexpr unsigned kKStages = Config::kGroupDim / 128;
     using Input = InputLayout<kTokenBatch, kNumWarps, Config::kGroupDim>;
     using W13 = MxFp4WeightLayout<kNumWarps, Config::kGroupDim>;
+    using ActivationOp = ActivationOp_;
 
     struct Shm {
         unsigned act[Input::kShmInputElements];
@@ -173,9 +172,13 @@ struct FusedMoEBlockScaleFP8Fp4Stage1Trait {
         }
     }
 
+    __device__ void AddBias(float4 t_gate[kAccumFragments],
+                            float4 t_up[kAccumFragments], unsigned wid,
+                            unsigned wtid) const {}
 };
 
-template <class Config> struct FusedMoEBlockScaleFP8Fp4KernelTrait {
+template <class Config, class ActivationOp = SiluDotOp>
+struct FusedMoEBlockScaleFP8Fp4KernelTrait {
     using Scalar = __hip_fp8_e4m3;
     static constexpr unsigned kNumWarps = Config::kNumWarps;
     static constexpr unsigned kThreads = kNumWarps * kWarpSize;
@@ -184,7 +187,7 @@ template <class Config> struct FusedMoEBlockScaleFP8Fp4KernelTrait {
     using W13 = MxFp4WeightLayout<kNumWarps, Config::kGroupDim>;
     using W2 = MxFp4WeightLayout<kNumWarps, Config::kGroupN>;
     using Stage1Trait =
-        FusedMoEBlockScaleFP8Fp4Stage1Trait<Config, kTokenBatch>;
+        FusedMoEBlockScaleFP8Fp4Stage1Trait<Config, ActivationOp, kTokenBatch>;
     using Stage1Op =
         OnestageFusedMoEStage1SingleBufferOp<Stage1Trait,
                                              Config::kGroupDim, kTokenBatch>;
@@ -321,6 +324,9 @@ template <class Config> struct FusedMoEBlockScaleFP8Fp4Stage2Trait {
                 scale_w2[stage][j], j);
         }
     }
+
+    __device__ void AddBias(float4 t[kAccumFragments], unsigned tile_d,
+                            unsigned wid, unsigned wtid) const {}
 
 };
 

--- a/lib/moe/rocm/fused_moe_blockscale_fp8_fp4_grid.cuh
+++ b/lib/moe/rocm/fused_moe_blockscale_fp8_fp4_grid.cuh
@@ -19,7 +19,8 @@
 
 namespace causalflow::petit::rocm::moe {
 
-template <class Config> struct FusedMoEBlockScaleFP8Fp4Stage2Trait;
+template <class Config, class BiasOp_>
+struct FusedMoEBlockScaleFP8Fp4Stage2Trait;
 
 __device__ static inline float4 Fma4(float4 a, float4 s, float4 c) {
     const auto *a2 = reinterpret_cast<const float2 *>(&a);
@@ -97,7 +98,7 @@ MatmulBlockScaleFp4(float4 t[2 * kLoadGlobal], const uint4 w[kLoadGlobal],
     }
 }
 
-template <class Config, class ActivationOp_, unsigned kTokenBatch>
+template <class Config, class ActivationOp_, class BiasOp_, unsigned kTokenBatch>
 struct FusedMoEBlockScaleFP8Fp4Stage1Trait {
     static constexpr unsigned kNumWarps = Config::kNumWarps;
     static constexpr unsigned kActivationFragments = Config::kGroupDim / 32;
@@ -105,6 +106,7 @@ struct FusedMoEBlockScaleFP8Fp4Stage1Trait {
     using Input = InputLayout<kTokenBatch, kNumWarps, Config::kGroupDim>;
     using W13 = MxFp4WeightLayout<kNumWarps, Config::kGroupDim>;
     using ActivationOp = ActivationOp_;
+    using BiasOp = BiasOp_;
 
     struct Shm {
         unsigned act[Input::kShmInputElements];
@@ -171,13 +173,9 @@ struct FusedMoEBlockScaleFP8Fp4Stage1Trait {
                 t_up, w3_tile[j], regs.x, regs.scale_x, scale_w3[j], j);
         }
     }
-
-    __device__ void AddBias(float4 t_gate[kAccumFragments],
-                            float4 t_up[kAccumFragments], unsigned wid,
-                            unsigned wtid) const {}
 };
 
-template <class Config, class ActivationOp = SiluDotOp>
+template <class Config, class ActivationOp, class BiasOp_>
 struct FusedMoEBlockScaleFP8Fp4KernelTrait {
     using Scalar = __hip_fp8_e4m3;
     static constexpr unsigned kNumWarps = Config::kNumWarps;
@@ -186,13 +184,15 @@ struct FusedMoEBlockScaleFP8Fp4KernelTrait {
     using Input = InputLayout<kTokenBatch, kNumWarps, Config::kGroupDim>;
     using W13 = MxFp4WeightLayout<kNumWarps, Config::kGroupDim>;
     using W2 = MxFp4WeightLayout<kNumWarps, Config::kGroupN>;
+    using BiasOp = BiasOp_;
     using Stage1Trait =
-        FusedMoEBlockScaleFP8Fp4Stage1Trait<Config, ActivationOp, kTokenBatch>;
+        FusedMoEBlockScaleFP8Fp4Stage1Trait<Config, ActivationOp,
+                                            BiasOp, kTokenBatch>;
     using Stage1Op =
         OnestageFusedMoEStage1SingleBufferOp<Stage1Trait,
                                              Config::kGroupDim, kTokenBatch>;
 
-    using Stage2Trait = FusedMoEBlockScaleFP8Fp4Stage2Trait<Config>;
+    using Stage2Trait = FusedMoEBlockScaleFP8Fp4Stage2Trait<Config, BiasOp>;
     using Stage2Op =
         OnestageFusedMoEStage2Op<Stage2Trait, Config::kGroupDim,
                                  kTokenBatch>;
@@ -280,13 +280,15 @@ struct FusedMoEBlockScaleFP8Fp4KernelTrait {
 
 template <class Config>
 using FusedMoEBlockScaleFP8Fp4Kernel =
-    OnestageFusedMoEBlockScaleFP8<Config,
-                                  FusedMoEBlockScaleFP8Fp4KernelTrait<Config>>;
+    OnestageFusedMoEBlockScaleFP8<
+        Config, FusedMoEBlockScaleFP8Fp4KernelTrait<Config, SiluDotOp, NoBiasOp>>;
 
-template <class Config> struct FusedMoEBlockScaleFP8Fp4Stage2Trait {
+template <class Config, class BiasOp_>
+struct FusedMoEBlockScaleFP8Fp4Stage2Trait {
     static constexpr unsigned kNumWarps = Config::kNumWarps;
     using Schedule = WarpSchedule<Config>;
     static constexpr int kKStages = Config::kGroupN / 128;
+    using BiasOp = BiasOp_;
     using W2 = MxFp4WeightLayout<kNumWarps, Config::kGroupN>;
     W2 &w2;
     uint4 w2_tile[2][kKStages][W2::kLoadGlobal];

--- a/lib/moe/rocm/fused_moe_blockscale_fp8_grid.cuh
+++ b/lib/moe/rocm/fused_moe_blockscale_fp8_grid.cuh
@@ -75,7 +75,7 @@ MatmulBlockScaleFp8(float4 t[8], const uint4 w[8], const uint4 x[8],
     }
 }
 
-template <class Config, class ActivationOp_, unsigned kTokenBatch>
+template <class Config, class ActivationOp_, class BiasOp_, unsigned kTokenBatch>
 struct FusedMoEBlockScaleFP8Stage1Trait {
     using Scalar = __hip_fp8_e4m3;
     static constexpr unsigned kNumWarps = Config::kNumWarps;
@@ -83,6 +83,7 @@ struct FusedMoEBlockScaleFP8Stage1Trait {
     using Input = InputLayout<kTokenBatch, kNumWarps, Config::kGroupDim>;
     using W13 = W13Layout<Scalar, kNumWarps, Config::kGroupN>;
     using ActivationOp = ActivationOp_;
+    using BiasOp = BiasOp_;
 
     struct Shm {
         unsigned act[Input::kShmInputElements];
@@ -154,8 +155,10 @@ struct FusedMoEBlockScaleFP8Stage1Trait {
                             unsigned wtid) const {}
 };
 
-template <class Config> struct FusedMoEBlockScaleFP8Stage2Trait {
+template <class Config, class BiasOp_>
+struct FusedMoEBlockScaleFP8Stage2Trait {
     static constexpr unsigned kNumWarps = Config::kNumWarps;
+    using BiasOp = BiasOp_;
     using W2 = W2Layout<__hip_fp8_e4m3, kNumWarps, Config::kGroupN>;
     W2 &w2;
     uint4 w2_tile[2][2][W2::kLoadGlobal];
@@ -188,13 +191,9 @@ template <class Config> struct FusedMoEBlockScaleFP8Stage2Trait {
         MatmulBlockScaleFp8<Stage2ScaleDppCtrl>(
             t, w2_tile[stage][1], input.x, input.scale, scale_w2[stage], 1);
     }
-
-    __device__ void AddBias(float4 t[kAccumFragments], unsigned tile_d,
-                            unsigned wid, unsigned wtid) const {}
-
 };
 
-template <class Config, class ActivationOp = SiluDotOp>
+template <class Config, class ActivationOp, class BiasOp_>
 struct FusedMoEBlockScaleFP8KernelTrait {
     using Scalar = __hip_fp8_e4m3;
     static constexpr unsigned kNumWarps = Config::kNumWarps;
@@ -203,12 +202,14 @@ struct FusedMoEBlockScaleFP8KernelTrait {
     using Input = InputLayout<kTokenBatch, kNumWarps, Config::kGroupDim>;
     using W2 = W2Layout<Scalar, kNumWarps, Config::kGroupN>;
     using W13 = W13Layout<Scalar, kNumWarps, Config::kGroupN>;
+    using BiasOp = BiasOp_;
     using Stage1Trait =
-        FusedMoEBlockScaleFP8Stage1Trait<Config, ActivationOp, kTokenBatch>;
+        FusedMoEBlockScaleFP8Stage1Trait<Config, ActivationOp,
+                                         BiasOp, kTokenBatch>;
     using Stage1Op =
         OnestageFusedMoEStage1DoubleBufferOp<Stage1Trait,
                                              Config::kGroupDim, kTokenBatch>;
-    using Stage2Trait = FusedMoEBlockScaleFP8Stage2Trait<Config>;
+    using Stage2Trait = FusedMoEBlockScaleFP8Stage2Trait<Config, BiasOp>;
     using Stage2Op =
         OnestageFusedMoEStage2Op<Stage2Trait, Config::kGroupDim,
                                  kTokenBatch>;
@@ -276,8 +277,8 @@ struct FusedMoEBlockScaleFP8KernelTrait {
 
 template <class Config>
 using FusedMoEBlockScaleFP8Kernel =
-    OnestageFusedMoEBlockScaleFP8<Config,
-                                  FusedMoEBlockScaleFP8KernelTrait<Config>>;
+    OnestageFusedMoEBlockScaleFP8<
+        Config, FusedMoEBlockScaleFP8KernelTrait<Config, SiluDotOp, NoBiasOp>>;
 
 struct FusedMoEConfig {
     static constexpr unsigned kGroupM = 32;

--- a/lib/moe/rocm/fused_moe_blockscale_fp8_grid.cuh
+++ b/lib/moe/rocm/fused_moe_blockscale_fp8_grid.cuh
@@ -75,13 +75,14 @@ MatmulBlockScaleFp8(float4 t[8], const uint4 w[8], const uint4 x[8],
     }
 }
 
-template <class Config, unsigned kTokenBatch>
+template <class Config, class ActivationOp_, unsigned kTokenBatch>
 struct FusedMoEBlockScaleFP8Stage1Trait {
     using Scalar = __hip_fp8_e4m3;
     static constexpr unsigned kNumWarps = Config::kNumWarps;
     static constexpr unsigned kActivationFragments = 8;
     using Input = InputLayout<kTokenBatch, kNumWarps, Config::kGroupDim>;
     using W13 = W13Layout<Scalar, kNumWarps, Config::kGroupN>;
+    using ActivationOp = ActivationOp_;
 
     struct Shm {
         unsigned act[Input::kShmInputElements];
@@ -148,6 +149,9 @@ struct FusedMoEBlockScaleFP8Stage1Trait {
         }
     }
 
+    __device__ void AddBias(float4 t_gate[kAccumFragments],
+                            float4 t_up[kAccumFragments], unsigned wid,
+                            unsigned wtid) const {}
 };
 
 template <class Config> struct FusedMoEBlockScaleFP8Stage2Trait {
@@ -185,9 +189,13 @@ template <class Config> struct FusedMoEBlockScaleFP8Stage2Trait {
             t, w2_tile[stage][1], input.x, input.scale, scale_w2[stage], 1);
     }
 
+    __device__ void AddBias(float4 t[kAccumFragments], unsigned tile_d,
+                            unsigned wid, unsigned wtid) const {}
+
 };
 
-template <class Config> struct FusedMoEBlockScaleFP8KernelTrait {
+template <class Config, class ActivationOp = SiluDotOp>
+struct FusedMoEBlockScaleFP8KernelTrait {
     using Scalar = __hip_fp8_e4m3;
     static constexpr unsigned kNumWarps = Config::kNumWarps;
     static constexpr unsigned kThreads = kNumWarps * kWarpSize;
@@ -195,7 +203,8 @@ template <class Config> struct FusedMoEBlockScaleFP8KernelTrait {
     using Input = InputLayout<kTokenBatch, kNumWarps, Config::kGroupDim>;
     using W2 = W2Layout<Scalar, kNumWarps, Config::kGroupN>;
     using W13 = W13Layout<Scalar, kNumWarps, Config::kGroupN>;
-    using Stage1Trait = FusedMoEBlockScaleFP8Stage1Trait<Config, kTokenBatch>;
+    using Stage1Trait =
+        FusedMoEBlockScaleFP8Stage1Trait<Config, ActivationOp, kTokenBatch>;
     using Stage1Op =
         OnestageFusedMoEStage1DoubleBufferOp<Stage1Trait,
                                              Config::kGroupDim, kTokenBatch>;

--- a/lib/moe/rocm/fused_moe_blockscale_fp8_kernel.cuh
+++ b/lib/moe/rocm/fused_moe_blockscale_fp8_kernel.cuh
@@ -28,6 +28,7 @@ struct OnestageFusedMoEBlockScaleFP8 {
     using Stage1Op = typename KernelTrait::Stage1Op;
     using Stage2Trait = typename KernelTrait::Stage2Trait;
     using Stage2Op = typename KernelTrait::Stage2Op;
+    using BiasOp = typename KernelTrait::BiasOp;
 
     struct ShmBuf {
         typename Stage1Op::Shm x;
@@ -64,20 +65,21 @@ struct OnestageFusedMoEBlockScaleFP8 {
     __device__ void Stage1(float4 h[Stage1Trait::kAccumFragments], ShmBuf &shm,
                            unsigned wid, unsigned wtid, unsigned tid,
                            const uint2 token_select,
-                           const unsigned tokens[kTokenBatch], unsigned m) {
+                           const unsigned tokens[kTokenBatch], unsigned m,
+                           BiasOp &bias_op) {
         Stage1Trait trait{input_, w1_, w3_};
         Stage1Op::Run(h, shm.x, trait, dim_, tid, wid, wtid, token_select,
-                      tokens, m);
+                      tokens, m, bias_op);
     }
 
     __device__ void
     Stage2(uint4 *__restrict__ out, ShmBuf &shm,
            const typename Stage2Trait::InputRegs &input, float2 sorted_weights,
            const unsigned tokens[kTokenBatch], unsigned invalid_token_mask,
-           unsigned tid, unsigned wid, unsigned wtid) {
+           unsigned tid, unsigned wid, unsigned wtid, BiasOp &bias_op) {
         Stage2Trait trait{w2_};
         Stage2Op::Run(out, shm.ret, trait, dim_, input, sorted_weights, tokens,
-                      invalid_token_mask, tid, wid, wtid);
+                      invalid_token_mask, tid, wid, wtid, bias_op);
     }
 
     __device__ void
@@ -135,6 +137,7 @@ struct OnestageFusedMoEBlockScaleFP8 {
                         tile_k, n_blocks, k_blocks);
                     sorted_token_br_ = MakeBufferResource(
                         sorted_token_ids + route_base, kRefBufferRange);
+                    bias_op_.Initialize(*this);
 
                     uint2 token_select;
                     token_select.x =
@@ -171,7 +174,7 @@ struct OnestageFusedMoEBlockScaleFP8 {
                         LoadSortedWeights(sorted_weights_ptr, tid, route_base);
                     float4 h[Stage1Trait::kAccumFragments];
                     Stage1(h, shm, wid, wtid, tid, safe_token_select,
-                           safe_tokens, m);
+                           safe_tokens, m, bias_op_);
                     __syncthreads();
 
                     unsigned invalid_token_mask = 0;
@@ -186,7 +189,7 @@ struct OnestageFusedMoEBlockScaleFP8 {
                                               tid, wid, wtid);
 
                     Stage2(out, shm, stage2_input, sorted_weights, safe_tokens,
-                           invalid_token_mask, tid, wid, wtid);
+                           invalid_token_mask, tid, wid, wtid, bias_op_);
                 }
             }
             __syncthreads();
@@ -196,6 +199,7 @@ struct OnestageFusedMoEBlockScaleFP8 {
     unsigned dim_;
     unsigned inter_dim_;
     Input input_;
+    BiasOp bias_op_;
     BufferResource sorted_token_br_;
     W2 w2_;
     W13 w1_, w3_;

--- a/lib/moe/rocm/ops/onestage_fused_moe_stage1.cuh
+++ b/lib/moe/rocm/ops/onestage_fused_moe_stage1.cuh
@@ -10,6 +10,7 @@ template <class Trait, unsigned kGroupDim, unsigned kTokenBatch>
 struct OnestageFusedMoEStage1DoubleBufferOp {
     static constexpr unsigned kStage = 2;
     using Input = typename Trait::Input;
+    using ActivationOp = typename Trait::ActivationOp;
     static constexpr unsigned kAccumFragments = Trait::kAccumFragments;
 
     struct Shm {
@@ -54,8 +55,9 @@ struct OnestageFusedMoEStage1DoubleBufferOp {
             }
         }
 
+        trait.AddBias(t_gate, t_up, wid, wtid);
         for (unsigned i = 0; i < kAccumFragments; i++) {
-            h[i] = SiluDot(t_gate[i], t_up[i]);
+            h[i] = ActivationOp::Apply(t_gate[i], t_up[i]);
         }
     }
 };
@@ -64,6 +66,7 @@ template <class Trait, unsigned kGroupDim, unsigned kTokenBatch>
 struct OnestageFusedMoEStage1SingleBufferOp {
     static constexpr unsigned kStage = 1;
     using Input = typename Trait::Input;
+    using ActivationOp = typename Trait::ActivationOp;
     static constexpr unsigned kAccumFragments = Trait::kAccumFragments;
 
     struct Shm {
@@ -88,8 +91,9 @@ struct OnestageFusedMoEStage1SingleBufferOp {
             trait.Matmul(t_gate, t_up, x, tid, wid, wtid);
         }
 
+        trait.AddBias(t_gate, t_up, wid, wtid);
         for (unsigned i = 0; i < kAccumFragments; i++) {
-            h[i] = SiluDot(t_gate[i], t_up[i]);
+            h[i] = ActivationOp::Apply(t_gate[i], t_up[i]);
         }
     }
 };

--- a/lib/moe/rocm/ops/onestage_fused_moe_stage1.cuh
+++ b/lib/moe/rocm/ops/onestage_fused_moe_stage1.cuh
@@ -11,6 +11,7 @@ struct OnestageFusedMoEStage1DoubleBufferOp {
     static constexpr unsigned kStage = 2;
     using Input = typename Trait::Input;
     using ActivationOp = typename Trait::ActivationOp;
+    using BiasOp = typename Trait::BiasOp;
     static constexpr unsigned kAccumFragments = Trait::kAccumFragments;
 
     struct Shm {
@@ -21,7 +22,8 @@ struct OnestageFusedMoEStage1DoubleBufferOp {
                                Trait &trait, unsigned dim, unsigned tid,
                                unsigned wid, unsigned wtid,
                                const uint2 token_select,
-                               const unsigned tokens[kTokenBatch], unsigned m) {
+                               const unsigned tokens[kTokenBatch], unsigned m,
+                               BiasOp& bias_op) {
         float4 t_gate[kAccumFragments], t_up[kAccumFragments];
         typename Trait::InputRegs x[kStage];
         ClearMat(t_gate);
@@ -55,7 +57,7 @@ struct OnestageFusedMoEStage1DoubleBufferOp {
             }
         }
 
-        trait.AddBias(t_gate, t_up, wid, wtid);
+        bias_op.template AddBiasStage1<kAccumFragments>(t_gate, t_up, wid, wtid);
         for (unsigned i = 0; i < kAccumFragments; i++) {
             h[i] = ActivationOp::Apply(t_gate[i], t_up[i]);
         }
@@ -67,6 +69,7 @@ struct OnestageFusedMoEStage1SingleBufferOp {
     static constexpr unsigned kStage = 1;
     using Input = typename Trait::Input;
     using ActivationOp = typename Trait::ActivationOp;
+    using BiasOp = typename Trait::BiasOp;
     static constexpr unsigned kAccumFragments = Trait::kAccumFragments;
 
     struct Shm {
@@ -76,7 +79,8 @@ struct OnestageFusedMoEStage1SingleBufferOp {
     __device__ static void Run(float4 h[kAccumFragments], Shm &shm, Trait &trait,
                                unsigned dim, unsigned tid, unsigned wid,
                                unsigned wtid, const uint2 token_select,
-                               const unsigned tokens[kTokenBatch], unsigned m) {
+                               const unsigned tokens[kTokenBatch], unsigned m,
+                               BiasOp& bias_op) {
         float4 t_gate[kAccumFragments], t_up[kAccumFragments];
         typename Trait::InputRegs x;
         ClearMat(t_gate);
@@ -91,7 +95,7 @@ struct OnestageFusedMoEStage1SingleBufferOp {
             trait.Matmul(t_gate, t_up, x, tid, wid, wtid);
         }
 
-        trait.AddBias(t_gate, t_up, wid, wtid);
+        bias_op.template AddBiasStage1<kAccumFragments>(t_gate, t_up, wid, wtid);
         for (unsigned i = 0; i < kAccumFragments; i++) {
             h[i] = ActivationOp::Apply(t_gate[i], t_up[i]);
         }

--- a/lib/moe/rocm/ops/onestage_fused_moe_stage2.cuh
+++ b/lib/moe/rocm/ops/onestage_fused_moe_stage2.cuh
@@ -66,6 +66,7 @@ struct OnestageFusedMoEStage2Op {
     static constexpr unsigned kActivationFragments =
         Trait::kActivationFragments;
     static constexpr unsigned kTokenPairs = kTokenBatch / 2;
+    using BiasOp = typename Trait::BiasOp;
 
     static_assert(Trait::kNumWarps == kNumWarps, "");
     static_assert(kTokenBatch % 2 == 0, "");
@@ -135,7 +136,8 @@ struct OnestageFusedMoEStage2Op {
                                float2 sorted_weights,
                                const unsigned tokens[kTokenBatch],
                                unsigned invalid_token_mask, unsigned tid,
-                               unsigned wid, unsigned wtid) {
+                               unsigned wid, unsigned wtid,
+                               BiasOp& bias_op) {
         unsigned curr = 0, next = 1;
         trait.LoadStage(curr, tid, wid, wtid);
         uint2 zeroes[kAccumFragments] = {
@@ -162,7 +164,7 @@ struct OnestageFusedMoEStage2Op {
                 uint2 ret[kTokenBatch];
                 ReadShm(shm, next, ret, wid, wtid);
                 trait.Matmul(t, input, curr, wtid);
-                trait.AddBias(t, tile_d, wid, wtid);
+                bias_op.template AddBiasStage2<kAccumFragments>(t, tile_d, wid, wtid);
                 MultRouteWeights<kAccumFragments>(t, sorted_weights);
                 uint2 o[kAccumFragments];
                 for (unsigned i = 0; i < kAccumFragments; i++) {

--- a/lib/moe/rocm/ops/onestage_fused_moe_stage2.cuh
+++ b/lib/moe/rocm/ops/onestage_fused_moe_stage2.cuh
@@ -162,6 +162,7 @@ struct OnestageFusedMoEStage2Op {
                 uint2 ret[kTokenBatch];
                 ReadShm(shm, next, ret, wid, wtid);
                 trait.Matmul(t, input, curr, wtid);
+                trait.AddBias(t, tile_d, wid, wtid);
                 MultRouteWeights<kAccumFragments>(t, sorted_weights);
                 uint2 o[kAccumFragments];
                 for (unsigned i = 0; i < kAccumFragments; i++) {


### PR DESCRIPTION
This PR refactors the internal one-stage fused MoE stage1/stage2 path to support pluggable activation ops and bias hooks, while keeping current FP8 and FP8+MXFP4 behavior unchanged through no-op `AddBias` implementations. It also fixes BF16 round-to-nearest-even conversion in stage2.

Tested with `git diff --check`, `fused_moe_blockscale_fp8_test`, and `fused_moe_blockscale_fp8_fp4_test`.
